### PR TITLE
set default paper size at configuration time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ distclean: clean
 
 u2ps.o: config.h
 u2ps*.o: u2ps.h
-u2ps_opts.o: u2ps_data.h
+u2ps_opts.o: u2ps_data.h config.h
 u2ps_data.o: u2ps_data.i
 u2ps_pswr.o: config.h
 

--- a/configure
+++ b/configure
@@ -2,6 +2,14 @@
 
 unset prefix bindir datadir mandir man1dir basedir gs psfremdir cross
 
+if [ -r /etc/papersize ]; then
+  defaultpaper=$(cat /etc/papersize)
+else
+  defaultpaper=a4
+fi
+
+
+
 help() {
 cat << EOF
 Usage: $0 [OPTIONS]...
@@ -14,6 +22,7 @@ Options:
 	--mandir=/path		base directory for manual pages [\$datadir/man]
 	--man1dir=/path		directory for manual section 1 pages [\$mandir/man1]
 	--with-gs=...		gs command to use [gs]
+        --default-paper=...     default paper size [$defaultpaper]
 
 EOF
 exit
@@ -50,6 +59,7 @@ for arg in "$@"; do
 		cflags) cflags="$val" ;;
 		devel) cflags="-Wall -g"; basedir="res"; psfremdir="./" ;;
 		target) cross="$val-" ;;
+                default-paper) defaultpaper="$val" ;;
 		*)
 			echo "unexpected parameter $arg"
 			exit 1
@@ -86,6 +96,7 @@ cat > config.h <<END
 #define GS "$gs"
 #define PATH "$psfremdir"
 #define BASE "$basedir"
+#define PAPER "$defaultpaper"
 END
 
 cat > config.mk <<END
@@ -103,4 +114,5 @@ echo "u2ps executable dir: $bindir"
 echo "u2ps postscript dir: $basedir"
 echo "man section 1 path: $man1dir"
 echo "ghostscript command: $gs"
+echo "default paper size: $defaultpaper"
 echo 

--- a/u2ps_opts.c
+++ b/u2ps_opts.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "config.h"
 #include "u2ps.h"
 #include "warn.h"
 #include "u2ps_data.h"
@@ -392,6 +393,10 @@ static int got_headings_set(void)
 	return memcmp(&headings, zero, size);
 }
 
+// to avoid horror of shell quoting, quote the paper size using C macros
+#define STRINGIZE(A) #A
+#define XSTR(S) STRINGIZE(S)
+
 static void set_page_layout(struct pagelayout* pl)
 {
 	const struct papersize* p;
@@ -403,7 +408,7 @@ static void set_page_layout(struct pagelayout* pl)
 	if(!paper)
 		paper = getenv("PAPER");
 	if(!paper)
-		paper = "a4";
+		paper = PAPER;
 
 	for(p = papersize; p->name; p++)
 		if(!strcmp(p->name, paper))


### PR DESCRIPTION
Paper size no longer defaults to a4.  Instead, it is taken from
/etc/papersize or from an argument to configure.