### PR TITLE
the page margins are integers

### DIFF
--- a/u2ps_opts.c
+++ b/u2ps_opts.c
@@ -27,8 +27,8 @@ struct runopts runopts;
 
 struct pagelayout pagelayout = {
 	.pw = 595, .ph = 842,       /* A4 */
-	.mt = 55,  .ml = 57.5,      /* some reasonable margins */
-	.mb = 55,  .mr = 57.5
+	.mt = 55,  .ml = 57,      /* some reasonable margins */
+	.mb = 55,  .mr = 57
 };
 
 int auxsize; /* centipoints */


### PR DESCRIPTION
```
u2ps_opts.c:31:19: warning: implicit conversion from 'double' to 'int' changes value from 57.5 to 57 [-Wliteral-conversion]
        .mb = 55,  .mr = 57.5
                         ^~~~
u2ps_opts.c:30:19: warning: implicit conversion from 'double' to 'int' changes value from 57.5 to 57 [-Wliteral-conversion]
        .mt = 55,  .ml = 57.5,      /* some reasonable margins */
                         ^~~~
```