### PR TITLE
rewrite manpages in mdoc(7)

### DIFF
--- a/psfrem.1
+++ b/psfrem.1
@@ -1,62 +1,101 @@
-.TH psfrem 1
-'''
-.SH NAME
-psfrem \- postscript font and resource embedding utility.
-'''
-.SH SYNOPSIS
-psfrem [\fIoptions\fR] \fIinput-file\fR [\fIoutput-file\fR]
-'''
-.SH DESCRIPTION
-\fBpsfrem\fR runs supplied PostScript document through Ghostscript,
-gathering font usage information, then dumps loaded font data from
-Ghostscript memory and embeds it into the source file. The resulting
-document is expected to be self-containing, with no dependencies on
-the fonts installed in a particular postscript device.
-
-When embedding fonts, \fBpsfrem\fR attempts to modify them, leaving
-only the glyphs used in the document, thus reducing the font size.
-
-\fBpsfrem\fR also attempts to embed non-font resources in place of
-%%IncludeResource directives.
-'''
-.SH USAGE
-Input file name must be supplied, and it must be a real seekable file.
-The output will be written to the specified file, or to stdout.
-'''
-.IP "\fB-I\fIdir\fR" 4
-Look for resources to embed in \fIdir\fR. This option may be specified
-more than once. This option is also passed to \fBgs\fR.
-.IP "\fB-d\fIvar\fR[=\fIval\fR]" 4
-Define PostScript variable \fIname\fR (with value \fIval\fR). This option
-is passed directly to \fBgs\fR(1).
-.IP "\fB-r\fR" 4
-Do reduce/embed fonts. Without this option, just embed resources.
-.IP "\fB-x\fIFont\fR" 4
-Do not dump/embed \fIFont\fR, which must be the PostScript font name
-(something like Times-Roman or FreeMono).
-.IP "\fB-a\fIFont\fR" 4
-Embed \fIFont\fR completely, do not attempt to remove unused glyphs.
-.IP "\fB-A\fR" 4
-Do embed Adobe core fonts. See NOTES below.
-.IP "\fB-k\fR" 4
+.Dd June 23, 2023
+.Dt PSFREM 1
+.Os
+.Sh NAME
+.Nm psfrem
+.Nd embed fonts and other resources in postscript files
+.Sh SYNOPSIS
+.Nm
+.Op Fl A
+.Op Fl a Ar font
+.Op Fl d Ar var=val
+.Op Fl I Ar dir
+.Op Fl k
+.Op Fl r
+.Op Fl x Ar font
+.Ar input
+.Op Ar output
+.Sh DESCRIPTION
+.Nm
+runs the supplied
+.Ar input
+postscript file through
+.Xr gs 1 ,
+gathering font usage information,
+and embeds the font data into the file.
+The resulting file is thus self-contained,
+with no external dependencies on fonts being installed
+in a particular postscript device.
+.Nm
+attempts to modify the embedded fonts,
+leaving only the glyphs used in the document,
+thus reducing the file size.
+.Nm
+also attempts to embed non-font resources in place of
+.Sq %%IncludeResource
+directives.
+The result is stored in the named
+.Ar output
+file or written to standard output.
+.Pp
+The options are as follows:
+.Bl -tag -width fontxxxxxxxx -compact
+.It Fl I Ar dir
+Look for resources to embed in
+.Ar dir .
+This option may be specified more than once
+and is also passed to
+.Xr gs 1 .
+.It Fl d Ar var Ns Op =val
+Pass variable
+.Ar var
+(with value
+.Ar val )
+to
+.Xr gs 1 .
+.It Fl r
+Do reduce/embed fonts.
+Without
+.Fl r ,
+just embed resources.
+.It Fl x Ar font
+Do not dump/embed the named
+.Ar font .
+This is expected to be a PostScript font name
+such as
+.Sq Times-Roman
+or
+.Sq FreeMono .
+.It Fl a Ar font
+Embed
+.Ar font
+completely, do not remove unused glyphs.
+.It Fl A
+Do embed Adobe core fonts; see below.
+.It Fl k
 Keep temporary files.
-'''
-.SH NOTES
-\fBpsfrem\fR is meant to be used with \fBu2ps\fR(1). It relies heavily
-on the input file being well-formed and well-behaved.
-It may or may not work with arbitrary PostScript input.
-
-\fBpsfrem\fR only looks for resource in directories explicitly specified
-with \fB-I\fR and does not know about standard \fBgs\fR search path.
-If you need to embed anything from /usr/share/ghostscript, pass relevant
-directories with \fB-I\fR.
-
-All PostScript interpreters are assumed to have a bunch of standard fonts
-available (Courier, Times-Roman, Helvetica, Symbol etc), so psfrem does not
-try to embed those. Glyph coverage beyond basic Latin is not guaranteed for
-standard fonts however, so it may be necessary to use \fB-A\fR, forcing the
-fonts available to Ghostscript locally to be embedded instead of relying on
-whatever the target device has got.
-'''
-.SH SEE ALSO
-\fBu2ps\fR(1), \fBgs\fR(1), \fBincluderes\fR(1) from psutils package.
+.El
+.Pp
+.Nm
+is meant to be used with
+.Xr u2ps 1 .
+It relies heavily on the input file being well-formed and well-behaved;
+it may not work with arbitrary PostScript input.
+.Nm
+only looks for resources in directories explicitly specified with
+.Fl I
+and does not know about standard
+.Xr gs 1
+search paths.
+All PostScript interpreters are assumed to have a bunch of
+standard fonts available (Courier, Times-Roman, Helvetica, Symbol etc), so
+.Nm
+psfrem does not try to embed those.
+Glyph coverage beyond basic Latin is not guaranteed for standard fonts however,
+so it may be necessary to use the
+.Fl A
+option.
+.Sh SEE ALSO
+.Xr gs 1 ,
+.Xr includeres 1 ,
+.Xr u2ps 1


### PR DESCRIPTION
Currently, the manpages u2ps(1) and psfrem(1)
are written in the traditional man(7) markup language.
I am proposing to rewrite them into the semantic markup
of the mdoc(7) language. I am willing to do the work.

Both the man(7) and mdoc(7) languages have been around for decades,
and are supported by the prevalent formatters: groff(1) on most Linuxes
and mandoc(1) on the *BSDs and some others. In particular,
there is nothing to install or reconfigure on most systems
- both formats can be rendered with man(1)
or processed into plaintext, html, pdf, or ps.

The main point is that mdoc(7) allows for constructs like

        .Op Fl f Ar arg

meaning

        there is an optional 'f' flag
        which takes an 'arg' argument

as opposed to

        switch to italics, type a bracket, a dash, "f",
        then switch to boldface and type "arg"

in the physical roff markup of man(7).

Similarly for other constructs like cross-references,
filenames, author emails, env variables, etc.

As an example, here is a rewrite of psfrem.1; while here,
* spell the [options] out explicitly
* fix "-d var" vs "-d name"
* slight reformulations